### PR TITLE
All right, rty 11, seems to be available on Jitci & everywhere else i…

### DIFF
--- a/.github/workflows.main.yml
+++ b/.github/workflows.main.yml
@@ -1,0 +1,10 @@
+runs-on: ubuntu-latest
+steps:
+  - name: Checkout the code
+    uses: actions/checkout@v2
+
+  - name: Set up Java
+    uses: actions/setup-java@v2
+    with:
+      distribution: "temurin"
+      java-version: 17

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -13,10 +13,10 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
-    - name: set up JDK 17
+    - name: set up JDK 11
       uses: actions/setup-java@v4
       with:
-        java-version: '17'
+        java-version: '11'
         distribution: 'temurin'
         cache: gradle
 

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -22,10 +22,10 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
-    - name: Set up JDK 17
+    - name: Set up JDK 11
       uses: actions/setup-java@v4
       with:
-        java-version: '17'
+        java-version: '11'
         distribution: 'temurin'
 
     # Configure Gradle for optimal use in GitHub Actions, including caching of downloaded dependencies.
@@ -55,10 +55,10 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
-    - name: Set up JDK 17
+    - name: Set up JDK 11
       uses: actions/setup-java@v4
       with:
-        java-version: '17'
+        java-version: '11'
         distribution: 'temurin'
 
     # Generates and submits a dependency graph, enabling Dependabot Alerts for all project dependencies.

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,3 @@
 android.useAndroidX=true
-android.enableJetifier=true
 org.gradle.jvmargs=-Duser.language=en -Duser.country=US -Dfile.encoding=UTF-8 -Xmx4096m "-XX:MaxMetaspaceSize=6000m"
 org.gradle.configuration-cache=true

--- a/jitpack.yml
+++ b/jitpack.yml
@@ -1,9 +1,9 @@
 # configuration file for building snapshots and releases with jitpack.io
 jdk:
-  - openjdk17
+  - openjdk11
 before_install:
-   - sdk install java 17-open
-   - sdk use java 17-open
+   - sdk install java 11-open
+   - sdk use java 11-open
 env:
-   JAVA_HOME: "/home/jitpack/tools/jdk17"
+   JAVA_HOME: "/home/jitpack/tools/jdk11"
 

--- a/photoview/build.gradle
+++ b/photoview/build.gradle
@@ -17,7 +17,7 @@ dependencies {
 }
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(17)
+        languageVersion = JavaLanguageVersion.of(11)
     }
 }
 


### PR DESCRIPTION
Switching to JDK 11, all tools including Jitci support that so I can (hopefully) get everything building and publishing properly.

### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Switch to JDK 11 so all tools work properly, after some tweaks to the jitci build.

### :arrow_heading_down: What is the current behavior?
Fails with JDK 21, 17 or 13, unable to find that JDK in some tool.

### :new: What is the new behavior (if this is a feature change)?
Builds pass & jitci works.

### :boom: Does this PR introduce a breaking change?
No, the opposite: fixes jitci

### :bug: Recommendations for testing
Build the sample app and test normally (look at the pictures, most should display & allow you to zoom & move)

### :memo: Links to relevant issues/docs

### :thinking: Checklist before submitting

- [X] All projects build
- [X] Follows style guide lines 
- [X] Relevant documentation was updated - just notes in PRs and pushes
- [X] Rebased onto current develop
